### PR TITLE
Install appengine-go 1.7.7

### DIFF
--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -12,12 +12,12 @@ dl() {
 
 case "$FAB_ARCH" in
     i386)  
-        VERSION="go_appengine_sdk_linux_386-1.7.5.1.zip"
-        SHA1SUM="64de98afa0acb606f9a8b8dc3ebd9a97372bdbf4"
+        VERSION="go_appengine_sdk_linux_386-1.7.7.zip"
+        SHA1SUM="8055b757c517c1d910139470c2dd3a12ea0e0c49"
         ;;
     amd64) 
-        VERSION="go_appengine_sdk_linux_amd64-1.7.5.1.zip"
-        SHA1SUM="cf064296ae3b80ce64c48b6d03132a36718efd4a"
+        VERSION="go_appengine_sdk_linux_amd64-1.7.7.zip"
+        SHA1SUM="c53b275beb9ca6b4816c6b7d3df68cf7f5208e19"
         ;;
     *) 
         fatal "FAB_ARCH is not set or not recognized"


### PR DESCRIPTION
Zip files for 1.7.5.1 are no longer available.

Note: Other appengine-based appliances suffer from the same problem.
